### PR TITLE
Shifter e altri moduli

### DIFF
--- a/moduli/DRCU_N.vhd
+++ b/moduli/DRCU_N.vhd
@@ -1,0 +1,19 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity DRCU_N is
+    generic ( N : integer := 32 ); 
+    port (
+        X      : in  std_logic_vector(N - 1 downto 0);
+        INVERT : in  std_logic; 
+        Y      : out std_logic_vector(N - 1 downto 0)
+    ); 
+end DRCU_N;
+
+architecture RTL of DRCU_N is
+begin
+    INV_SIG : for I in X'range generate 
+        Y(I) <= X(I) when INVERT = '0' else X(N - 1 - I); 
+    end generate INV_SIG; 
+end RTL;
+

--- a/moduli/LOG_SHIFTER_32.vhd
+++ b/moduli/LOG_SHIFTER_32.vhd
@@ -1,0 +1,119 @@
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity LOG_SHIFTER_32 is
+    port (
+        X        : in  std_logic_vector(31 downto 0); 
+        SHAMT    : in  std_logic_vector(4 downto 0); 
+        SHIFT_OP : in  std_logic_vector(1 downto 0);
+        Y        : out std_logic_vector(31 downto 0)
+    ); 
+end LOG_SHIFTER_32;
+
+architecture STRUCT of LOG_SHIFTER_32 is
+    component DRCU_N is
+        generic ( N : integer := 32 ); 
+        port (
+            X      : in  std_logic_vector(N - 1 downto 0);
+            INVERT : in  std_logic; 
+            Y      : out std_logic_vector(N - 1 downto 0)
+        ); 
+    end component;
+
+    component SHIFTER_N_M is
+        generic ( 
+            N : integer := 32; -- number of bits 
+            M : integer := 1   -- fixed shift amount 
+        ); 
+        port (
+            X       : in  std_logic_vector(N - 1 downto 0);
+            ENABLE  : in  std_logic; 
+            FILL    : in  std_logic; -- bit used to fill the shifted spaces  
+            Y       : out std_logic_vector(N - 1 downto 0)
+        );
+    end component;
+    
+    signal IN_STAGE_1  : std_logic_vector(31 downto 0);
+    signal OUT_STAGE_1 : std_logic_vector(31 downto 0);
+    signal OUT_STAGE_2 : std_logic_vector(31 downto 0);
+    signal OUT_STAGE_3 : std_logic_vector(31 downto 0);
+    signal OUT_STAGE_4 : std_logic_vector(31 downto 0);
+    signal OUT_STAGE_5 : std_logic_vector(31 downto 0);
+    signal SIG_FILL    : std_logic; 
+    signal SIG_ENABLE  : std_logic_vector(4 downto 0); 
+    signal SIG_LEFT    : std_logic; 
+begin
+    SIG_LEFT <= (SHIFT_OP(0) and (not SHIFT_OP(1))); 
+
+    SIG_FILL <= X(31) when (SHIFT_OP(0) and SHIFT_OP(1)) = '1' else '0'; -- is sra
+    SIG_ENABLE <= "00000" when (SHIFT_OP(0) or SHIFT_OP(1)) = '0' else SHAMT; -- is no_shift 
+
+    -- D(ata) R(eversal) CU 1
+    U0 : DRCU_N 
+        generic map ( N => 32 )
+        port map (
+            X => X, 
+            INVERT => SIG_LEFT, 
+            Y => IN_STAGE_1
+        ); 
+
+    -- stage 1
+    U1 : SHIFTER_N_M 
+        generic map ( N => 32, M => 1 )
+        port map (
+            X => IN_STAGE_1, 
+            Y => OUT_STAGE_1, 
+            ENABLE => SIG_ENABLE(0), 
+            FILL => SIG_FILL
+        ); 
+
+    -- stage 2
+    U2 : SHIFTER_N_M 
+    generic map ( N => 32, M => 2 )
+    port map (
+        X => OUT_STAGE_1, 
+        Y => OUT_STAGE_2, 
+        ENABLE => SIG_ENABLE(1), 
+        FILL => SIG_FILL
+    ); 
+
+    -- stage 3
+    U3 : SHIFTER_N_M 
+        generic map ( N => 32, M => 4 )
+        port map (
+            X => OUT_STAGE_2, 
+            Y => OUT_STAGE_3, 
+            ENABLE => SIG_ENABLE(2), 
+            FILL => SIG_FILL
+        ); 
+
+    -- stage 4
+    U4 : SHIFTER_N_M 
+    generic map ( N => 32, M => 8 )
+    port map (
+        X => OUT_STAGE_3, 
+        Y => OUT_STAGE_4, 
+        ENABLE => SIG_ENABLE(3), 
+        FILL => SIG_FILL
+    ); 
+
+    -- stage 5
+    U5 : SHIFTER_N_M 
+    generic map ( N => 32, M => 16 )
+    port map (
+        X => OUT_STAGE_4, 
+        Y => OUT_STAGE_5, 
+        ENABLE => SIG_ENABLE(4), 
+        FILL => SIG_FILL
+    ); 
+
+    -- DRCU 2
+    U6 : DRCU_N 
+        generic map ( N => 32 )
+        port map (
+            X => OUT_STAGE_5, 
+            INVERT => SIG_LEFT, 
+            Y => Y
+        ); 
+end STRUCT;
+

--- a/moduli/SHIFTER_N_M.vhd
+++ b/moduli/SHIFTER_N_M.vhd
@@ -1,0 +1,27 @@
+library ieee;
+use ieee.std_logic_1164.ALL;
+
+entity SHIFTER_N_M is
+    generic ( 
+        N : integer := 32; -- number of bits 
+        M : integer := 1   -- fixed shift amount 
+    ); 
+    port (
+        X       : in  std_logic_vector(N - 1 downto 0);
+        ENABLE  : in  std_logic; 
+        FILL    : in  std_logic; -- bit used to fill the shifted spaces  
+        Y       : out std_logic_vector(N - 1 downto 0)
+    );
+end SHIFTER_N_M;
+
+architecture RTL of SHIFTER_N_M is
+begin
+    GEN_SIGS : for I in M to N - 1 generate
+        Y(I - M) <= X(I) when ENABLE = '1' else X(I - M);   
+    end generate GEN_SIGS;
+    
+    GEN_FILL : for I in N - M to N - 1 generate
+        Y(I) <= FILL when ENABLE = '1' else X(I);  
+    end generate GEN_FILL; 
+end RTL;
+

--- a/test/TB_DRCU_32.vhd
+++ b/test/TB_DRCU_32.vhd
@@ -1,0 +1,47 @@
+LIBRARY ieee;
+USE ieee.std_logic_1164.ALL;
+ 
+ENTITY TB_DRCU_32 IS
+END TB_DRCU_32;
+ 
+ARCHITECTURE behavior OF TB_DRCU_32 IS 
+ 
+    -- Component Declaration for the Unit Under Test (UUT)
+ 
+    COMPONENT DRCU_N
+    PORT(
+         X : IN  std_logic_vector(31 downto 0);
+         INVERT : IN  std_logic;
+         Y : OUT  std_logic_vector(31 downto 0)
+        );
+    END COMPONENT;
+    
+
+   --Inputs
+   signal X : std_logic_vector(31 downto 0);
+   signal INVERT : std_logic;
+
+ 	--Outputs
+   signal Y : std_logic_vector(31 downto 0);
+ 
+BEGIN
+ 
+	-- Instantiate the Unit Under Test (UUT)
+   uut: DRCU_N PORT MAP (
+          X => X,
+          INVERT => INVERT,
+          Y => Y
+        );
+
+   -- Stimulus process
+   stim_proc: process
+   begin		
+      X <= x"F0F000AB"; 
+      INVERT <= '0'; 
+      wait for 200 ns; 
+
+      INVERT <= '1'; 
+      wait;
+   end process;
+
+END;

--- a/test/TB_LOG_SHIFTER.vhd
+++ b/test/TB_LOG_SHIFTER.vhd
@@ -1,0 +1,68 @@
+LIBRARY ieee;
+USE ieee.std_logic_1164.ALL;
+ 
+ENTITY TB_LOG_SHIFTER IS
+END TB_LOG_SHIFTER;
+ 
+ARCHITECTURE behavior OF TB_LOG_SHIFTER IS 
+ 
+    -- Component Declaration for the Unit Under Test (UUT)
+ 
+    COMPONENT LOG_SHIFTER_32
+    PORT(
+         X : IN  std_logic_vector(31 downto 0);
+         SHAMT : IN  std_logic_vector(4 downto 0);
+         SHIFT_OP : IN  std_logic_vector(1 downto 0);
+         Y : OUT  std_logic_vector(31 downto 0)
+        );
+    END COMPONENT;
+    
+
+   --Inputs
+   signal X : std_logic_vector(31 downto 0);
+   signal SHAMT : std_logic_vector(4 downto 0);
+   signal SHIFT_OP : std_logic_vector(1 downto 0);
+
+ 	--Outputs
+   signal Y : std_logic_vector(31 downto 0);
+   
+BEGIN
+ 
+	-- Instantiate the Unit Under Test (UUT)
+   uut: LOG_SHIFTER_32 PORT MAP (
+          X => X,
+          SHAMT => SHAMT,
+          SHIFT_OP => SHIFT_OP,
+          Y => Y
+        );
+
+   -- Stimulus process
+   stim_proc: process
+   begin		
+      X <= x"B0F09090"; 
+      SHAMT <= "11111"; 
+      SHIFT_OP <= "00"; 
+      wait for 100 ns; 
+
+      SHAMT <= "00000"; 
+      SHIFT_OP <= "01"; 
+      wait for 100 ns; 
+
+      SHAMT <= "01010";
+      wait for 100 ns; 
+      
+      SHIFT_OP <= "10"; 
+      wait for 100 ns; 
+
+      SHIFT_OP <= "11"; 
+      wait for 100 ns; 
+
+      SHIFT_OP <= "10"; 
+      X <= x"00F0B090"; 
+      wait for 100 ns; 
+
+      SHIFT_OP <= "11"; 
+      wait;
+   end process;
+
+END;

--- a/test/TB_SHIFTER_N_M.vhd
+++ b/test/TB_SHIFTER_N_M.vhd
@@ -1,0 +1,66 @@
+LIBRARY ieee;
+USE ieee.std_logic_1164.ALL;
+ 
+ENTITY TB_SHIFTER_N_M IS
+END TB_SHIFTER_N_M;
+ 
+ARCHITECTURE behavior OF TB_SHIFTER_N_M IS 
+ 
+    -- Component Declaration for the Unit Under Test (UUT)
+ 
+    COMPONENT SHIFTER_N_M
+    GENERIC (
+         N : INTEGER := 32;
+         M : INTEGER := 1
+        ); 
+    PORT(
+         X : IN  std_logic_vector(31 downto 0);
+         ENABLE : IN  std_logic;
+         FILL : IN  std_logic;
+         Y : OUT  std_logic_vector(31 downto 0)
+        );
+    END COMPONENT;
+    
+
+   --Inputs
+   signal X : std_logic_vector(31 downto 0);
+   signal ENABLE : std_logic;
+   signal FILL : std_logic;
+
+ 	--Outputs
+   signal Y : std_logic_vector(31 downto 0);
+ 
+BEGIN
+ 
+	-- Instantiate the Unit Under Test (UUT)
+   uut: SHIFTER_N_M 
+        GENERIC MAP (
+          N => 32, 
+          M => 4
+        )
+        PORT MAP (
+          X => X,
+          ENABLE => ENABLE,
+          FILL => FILL,
+          Y => Y
+        );
+
+   -- Stimulus process
+   stim_proc: process
+   begin		
+      X <= x"B0F09092"; 
+      ENABLE <= '0'; 
+      FILL <= '0'; 
+      wait for 200 ns; 
+
+      ENABLE <= '1'; 
+      wait for 200 ns; 
+
+      FILL <= '1'; 
+		wait for 200 ns; 
+		
+		ENABLE <= '0'; 
+      wait;
+   end process;
+
+END;


### PR DESCRIPTION
Moduli aggiunti:
- DRCU_N (Data Reversal Control Unit): modulo che inverte l'ordine dei bit all'interno di un vettore di dimensione N, es: 10011 -> 11001. Il modulo è usato per fare lo shift a sinistra, infatti lo SLL equivale a: INVERSIONE -> SRL (shift a destra) -> INVERSIONE. Esegue l'inversione solo se abilitato. 
- SHIFTER_N_M: shifter (**verso destra**) a N bit con shift di M posizioni. Richiede di essere abilitato per eseguire lo shift di M posizioni, gli spazi lasciati liberi dallo shift sono riempiti con il bit di FILL specificato in ingresso. Il bit di FILL permette di fare sia lo shift logico che aritmetico. 
- LOG_SHIFTER_32: shifter logaritmico a 5 stadi (= 5 SHIFTER_32_M) che permette di eseguire tutte le operazioni di shift. 

Esempio di equivalenza tra shift a destra (SRL) e shift a sinistra (SLL): 
```
Shift a sinistra di 2 posizioni su 10110010: 
Risultato atteso: (10)11001000

Inversione con DRCU: 01001101
SRL: 00010011(01)
Inversione con DRCU: 11001000
```
