### PR TITLE
Top level

### DIFF
--- a/moduli/CONTROL_UNIT.vhd
+++ b/moduli/CONTROL_UNIT.vhd
@@ -43,8 +43,8 @@ begin
 							"110---000000001100001" when OPCODE = "000000" and FUNCT = "000011" else -- sra
 							"110011101000000000001" when OPCODE = "000000" and FUNCT = "101010" else -- slt
 							"110010101000000000001" when OPCODE = "000000" and FUNCT = "101011" else -- sltu
-							"010011101000000000001" when OPCODE = "001010" else -- slti
-							"010010101000000000001" when OPCODE = "001011" else -- sltiu
+							"011011101000000000001" when OPCODE = "001010" else -- slti
+							"011010101000000000001" when OPCODE = "001011" else -- sltiu
 							"-0-------001-0--00001" when OPCODE = "000010" else -- j
 							"-1-------001100000001" when OPCODE = "000011" else -- jal
 							"-0-----------10000001" when OPCODE = "000000" and FUNCT = "001000" else -- jr

--- a/moduli/CONTROL_UNIT.vhd
+++ b/moduli/CONTROL_UNIT.vhd
@@ -5,9 +5,10 @@ entity CONTROL_UNIT is
 	port(
 		OPCODE 	  : in std_logic_vector(5 downto 0);
 		FUNCT 	  : in std_logic_vector(5 downto 0);
+		LUI		  : out std_logic;
 		DST_REG    : out std_logic;
 		WR_REG     : out std_logic;
-		ALU_SRC   : out std_logic;
+		ALU_SRC    : out std_logic;
 		ALU_OP     : out std_logic_vector(5 downto 0);
 		BRANCH_BEQ : out std_logic;
 		BRANCH_BNE : out std_logic;
@@ -29,34 +30,37 @@ begin
 
 	SIGNAL_CONTROL <= "11000-100000000000001" when OPCODE = "000000" and FUNCT = "100000" else -- add
 							"11001-100000000000001" when OPCODE = "000000" and FUNCT = "100010" else -- sub
-							"01100-100000000000001" when OPCODE = "001000" and FUNCT = "------" else -- addiu
+							"01100-100000000000001" when OPCODE = "001000" else -- addi
 							"11000-001000000000001" when OPCODE = "000000" and FUNCT = "100100" else -- and
 							"11000-011000000000001" when OPCODE = "000000" and FUNCT = "100101" else -- or
 							"11011-001000000000001" when OPCODE = "000000" and FUNCT = "100111" else -- nor
 							"11000-011000000000001" when OPCODE = "000000" and FUNCT = "100110" else -- xor
-							"01100-001000000000001" when OPCODE = "001100" and FUNCT = "------" else -- andi
-							"01100-010000000000001" when OPCODE = "001101" and FUNCT = "------" else -- ori
-							"01100-011000000000001" when OPCODE = "001110" and FUNCT = "------" else -- xori
+							"01100-001000000000001" when OPCODE = "001100" else -- andi
+							"01100-010000000000001" when OPCODE = "001101" else -- ori
+							"01100-011000000000001" when OPCODE = "001110" else -- xori
 							"110---000000000100001" when OPCODE = "000000" and FUNCT = "000000" else -- sll
 							"110---000000001000001" when OPCODE = "000000" and FUNCT = "000010" else -- srl
 							"110---000000001100001" when OPCODE = "000000" and FUNCT = "000011" else -- sra
 							"110011101000000000001" when OPCODE = "000000" and FUNCT = "101010" else -- slt
 							"110010101000000000001" when OPCODE = "000000" and FUNCT = "101011" else -- sltu
-							"010011101000000000001" when OPCODE = "001010" and FUNCT = "------" else -- slti
-							"010010101000000000001" when OPCODE = "001011" and FUNCT = "------" else -- sltiu
-							"-0-------001-0--00001" when OPCODE = "000010" and FUNCT = "------" else -- j
-							"-1-------001100000001" when OPCODE = "000011" and FUNCT = "------" else -- jal
+							"010011101000000000001" when OPCODE = "001010" else -- slti
+							"010010101000000000001" when OPCODE = "001011" else -- sltiu
+							"-0-------001-0--00001" when OPCODE = "000010" else -- j
+							"-1-------001100000001" when OPCODE = "000011" else -- jal
 							"-0-----------10000001" when OPCODE = "000000" and FUNCT = "001000" else -- jr
-							"-0001-100100-00000001" when OPCODE = "000100" and FUNCT = "------" else -- beq
-							"-0001-100010-00000001" when OPCODE = "000101" and FUNCT = "------" else -- bne
-							"011---000000000000001" when OPCODE = "001111" and FUNCT = "------" else -- lui
-							"01100-100000000001111" when OPCODE = "100011" and FUNCT = "------" else -- lw
-							"-0100-100000000010011" when OPCODE = "101011" and FUNCT = "------" else -- sw
-							"---------------------"; -- default
-
+							"-0001-100100-00000001" when OPCODE = "000100" else -- beq
+							"-0001-100010-00000001" when OPCODE = "000101" else -- bne
+							"011---000000000000001" when OPCODE = "001111" else -- lui
+							"01100-100000000001111" when OPCODE = "100011" else -- lw
+							"-0100-100000000010011" when OPCODE = "101011" else -- sw
+							"000000000000000000000"; -- default
+	
+	LUI 		  <= '1' when OPCODE = "001111" else
+					  '0';
+					  
 	DST_REG    <= SIGNAL_CONTROL(20);
 	WR_REG     <= SIGNAL_CONTROL(19);
-	ALU_SRC   <= SIGNAL_CONTROL(18);
+	ALU_SRC    <= SIGNAL_CONTROL(18);
 	ALU_OP     <= SIGNAL_CONTROL(17 downto 12);
 	BRANCH_BEQ <= SIGNAL_CONTROL(11);
 	BRANCH_BNE <= SIGNAL_CONTROL(10);

--- a/moduli/MIPS_32.vhd
+++ b/moduli/MIPS_32.vhd
@@ -23,7 +23,8 @@ architecture STRUCT of MIPS_32 is
         port(
             OPCODE 	  : in std_logic_vector(5 downto 0);
             FUNCT 	  : in std_logic_vector(5 downto 0);
-            DST_REG    : out std_logic;
+            LUI		  : out std_logic;
+				DST_REG    : out std_logic;
             WR_REG     : out std_logic;
             ALU_SRC   : out std_logic;
             ALU_OP     : out std_logic_vector(5 downto 0);
@@ -146,6 +147,7 @@ architecture STRUCT of MIPS_32 is
     signal TEMP_IMM : std_logic_vector(31 downto 0);
 
     -- CU control signals
+	 signal SIG_LUI : std_logic;
     signal SIG_DST_REG : std_logic; 
     signal SIG_WR_REG : std_logic; 
     signal SIG_ALU_SRC : std_logic; 
@@ -181,9 +183,12 @@ begin
     -- CU 
     U1 : CONTROL_UNIT 
         port map (
-            OPCODE => SIG_INSTR(5 downto 0), 
-            FUNCT => SIG_INSTR(31 downto 26), 
-            DST_REG => SIG_DST_REG, 
+            -- OPCODE => SIG_INSTR(5 downto 0), 
+            -- FUNCT => SIG_INSTR(31 downto 26), 
+				OPCODE => SIG_INSTR(31 downto 26), 
+				FUNCT => SIG_INSTR(5 downto 0),
+            LUI => SIG_LUI,
+				DST_REG => SIG_DST_REG, 
             WR_REG => SIG_WR_REG, 
             ALU_SRC => SIG_ALU_SRC, 
             ALU_OP => SIG_ALU_OP, 
@@ -199,7 +204,8 @@ begin
             DATA_ENA => SIG_DATA_ENA, 
             FETCH_I => SIG_FETCH_I
         ); 
-
+		
+		
     -- Register File 
     U2: REG_UNIT
         port map (
@@ -255,8 +261,9 @@ begin
         ); 
 
     -- Write back 
-    SIG_WRITE_BACK <= DIN when SIG_MEM_TO_REG = '1' else SIG_SHIFT_OUT;
-
+    SIG_WRITE_BACK <= DIN when SIG_MEM_TO_REG = '1' else
+							 SIG_INSTR(15 downto 0) & x"0000" when SIG_LUI = '1' else
+						    SIG_SHIFT_OUT;
     -- Branch unit 
     U6 : MANAGEMENT_PC
         port map (

--- a/test/TB_MIPS.vhd
+++ b/test/TB_MIPS.vhd
@@ -1,0 +1,117 @@
+LIBRARY ieee;
+USE ieee.std_logic_1164.ALL;
+ 
+ENTITY TB_MIPS_32 IS
+END TB_MIPS_32;
+ 
+ARCHITECTURE behavior OF TB_MIPS_32 IS 
+ 
+    -- Component Declaration for the Unit Under Test (UUT)
+ 
+    COMPONENT MIPS_32
+    PORT(
+         CLK : IN  std_logic;
+         RST : IN  std_logic;
+         IADDR : OUT  std_logic_vector(31 downto 0);
+         IDATA : IN  std_logic_vector(31 downto 0);
+         IEN : OUT  std_logic;
+         DADDR : OUT  std_logic_vector(31 downto 0);
+         DOUT : OUT  std_logic_vector(31 downto 0);
+         DIN : IN  std_logic_vector(31 downto 0);
+         DOP : OUT  std_logic;
+         DEN : OUT  std_logic
+        );
+    END COMPONENT;
+    
+
+   --Inputs
+   signal CLK : std_logic;
+   signal RST : std_logic;
+   signal IDATA : std_logic_vector(31 downto 0);
+   signal DIN : std_logic_vector(31 downto 0);
+
+ 	--Outputs
+   signal IADDR : std_logic_vector(31 downto 0);
+   signal IEN : std_logic;
+   signal DADDR : std_logic_vector(31 downto 0);
+   signal DOUT : std_logic_vector(31 downto 0);
+   signal DOP : std_logic;
+   signal DEN : std_logic;
+ 
+BEGIN
+ 
+	-- Instantiate the Unit Under Test (UUT)
+   uut: MIPS_32 PORT MAP (
+          CLK => CLK,
+          RST => RST,
+          IADDR => IADDR,
+          IDATA => IDATA,
+          IEN => IEN,
+          DADDR => DADDR,
+          DOUT => DOUT,
+          DIN => DIN,
+          DOP => DOP,
+          DEN => DEN
+        );
+
+	process
+	begin
+		CLK <= '1';
+		wait for 25 ns;
+		CLK <= '0';
+		wait for 25 ns;
+	end process;
+	
+   -- Stimulus process
+   stim_proc: process
+   begin		
+		RST   <= '1';
+		IDATA <= (others => '0');
+		DIN   <= (others => '0');
+      wait for 50 ns;
+		
+		RST   <= '0';
+      wait for 50 ns;
+		
+		-- addi $t0, $t0, 4
+		IDATA <= x"21080004";
+		wait for 50 ns;
+		
+		-- addi $t1, $t1, 8
+		IDATA <= x"21290008";
+		wait for 50 ns;
+		
+		-- addi $t2, $t1, $t0
+		IDATA <= x"01285020";
+		wait for 50 ns;
+		
+		-- sub $t3, $t1, $t0
+		IDATA <= x"01285822";
+		wait for 50 ns;
+		
+		-- and $t4, $t2, $t1
+		IDATA <= x"01496024";
+		wait for 50 ns;
+		
+		-- lui $t5, 123
+		IDATA <= x"3c0d007b";
+		wait for 50 ns;
+		
+		-- addi $t0, $t5, 8
+		IDATA <= x"21a80008";
+		wait for 50 ns;
+		
+		-- addi $t1, $t1, 500
+		IDATA <= x"212901f4";
+		wait for 50 ns;
+		
+		-- sub $t3, $t0, $t1
+		IDATA <= x"01095822";
+		wait for 50 ns;
+		
+		
+
+      wait;
+   end process;
+
+END;

--- a/test/TB_MIPS_32.vhd
+++ b/test/TB_MIPS_32.vhd
@@ -1,0 +1,153 @@
+LIBRARY ieee;
+USE ieee.std_logic_1164.ALL;
+ 
+ENTITY TB_MIPS_32 IS
+END TB_MIPS_32;
+ 
+ARCHITECTURE behavior OF TB_MIPS_32 IS 
+ 
+    -- Component Declaration for the Unit Under Test (UUT)
+ 
+    COMPONENT MIPS_32
+    PORT(
+         CLK : IN  std_logic;
+         RST : IN  std_logic;
+         IADDR : OUT  std_logic_vector(31 downto 0);
+         IDATA : IN  std_logic_vector(31 downto 0);
+         IEN : OUT  std_logic;
+         DADDR : OUT  std_logic_vector(31 downto 0);
+         DOUT : OUT  std_logic_vector(31 downto 0);
+         DIN : IN  std_logic_vector(31 downto 0);
+         DOP : OUT  std_logic;
+         DEN : OUT  std_logic
+        );
+    END COMPONENT;
+    
+
+   --Inputs
+   signal CLK : std_logic;
+   signal RST : std_logic;
+   signal IDATA : std_logic_vector(31 downto 0);
+   signal DIN : std_logic_vector(31 downto 0);
+
+ 	--Outputs
+   signal IADDR : std_logic_vector(31 downto 0);
+   signal IEN : std_logic;
+   signal DADDR : std_logic_vector(31 downto 0);
+   signal DOUT : std_logic_vector(31 downto 0);
+   signal DOP : std_logic;
+   signal DEN : std_logic;
+ 
+BEGIN
+ 
+	-- Instantiate the Unit Under Test (UUT)
+   uut: MIPS_32 PORT MAP (
+          CLK => CLK,
+          RST => RST,
+          IADDR => IADDR,
+          IDATA => IDATA,
+          IEN => IEN,
+          DADDR => DADDR,
+          DOUT => DOUT,
+          DIN => DIN,
+          DOP => DOP,
+          DEN => DEN
+        );
+
+	process
+	begin
+		CLK <= '1';
+		wait for 25 ns;
+		CLK <= '0';
+		wait for 25 ns;
+	end process;
+	
+   -- Stimulus process
+   stim_proc: process
+   begin		
+		RST   <= '1';
+		IDATA <= (others => '0');
+		DIN   <= (others => '0');
+      wait for 50 ns;
+		
+		RST   <= '0';
+      wait for 50 ns;
+		
+		-- addi $t0, $t0, 4
+		IDATA <= x"21080004";
+		wait for 50 ns;
+		
+		-- addi $t1, $t1, 8
+		IDATA <= x"21290008";
+		wait for 50 ns;
+		
+		-- addi $t2, $t1, $t0
+		IDATA <= x"01285020";
+		wait for 50 ns;
+		
+		-- sub $t3, $t1, $t0
+		IDATA <= x"01285822";
+		wait for 50 ns;
+		
+		-- and $t4, $t2, $t1
+		IDATA <= x"01496024";
+		wait for 50 ns;
+		
+		-- lui $t5, 123
+		IDATA <= x"3c0d007b";
+		wait for 50 ns;
+		
+		-- addi $t0, $t5, 8
+		IDATA <= x"21a80008";
+		wait for 50 ns;
+		
+		-- addi $t1, $t1, 500
+		IDATA <= x"212901f4";
+		wait for 50 ns;
+		
+		-- sub $t3, $t0, $t1
+		IDATA <= x"01095822";
+		wait for 50 ns;
+		
+		-- ori $t3, $t5, 8
+		IDATA <= x"35ab0008";
+		wait for 50 ns;
+		
+		-- or $t6, $t6, $t5
+		IDATA <= x"01cd7025";
+		wait for 50 ns;
+		
+		-- addi $t0, $t0, 0
+		IDATA <= x"21080000";
+		wait for 50 ns;
+		
+		-- addi $t1, $t1, 0
+		IDATA <= x"21290000";
+		wait for 50 ns;
+		
+		-- or $t7, $t1, $t0
+		IDATA <= x"01287825";
+		wait for 50 ns;
+		
+		-- ori $t7, $zero, 8
+		IDATA <= x"340f0008";
+		wait for 50 ns;
+		
+		-- nor $t7, $t3, $t4
+		IDATA <= x"016c7827";
+		wait for 50 ns;
+		
+		-- nor $t7, $t1, $t0
+		IDATA <= x"01287827";
+		wait for 50 ns;
+		
+		-- xor $t7, $t1, $t0
+		IDATA <= x"01287826";		
+      wait;
+   end process;
+
+END;
+
+-- xor $t7, $t3, $t4
+-- IDATA <= x"016c7826";
+-- wait for 50 ns;

--- a/test/TB_MIPS_32_BRANCH.vhd
+++ b/test/TB_MIPS_32_BRANCH.vhd
@@ -1,0 +1,145 @@
+LIBRARY ieee;
+USE ieee.std_logic_1164.ALL;
+ 
+ENTITY TB_MIPS_32_BRANCH IS
+END TB_MIPS_32_BRANCH;
+ 
+ARCHITECTURE behavior OF TB_MIPS_32_BRANCH IS 
+ 
+    -- Component Declaration for the Unit Under Test (UUT)
+ 
+    COMPONENT MIPS_32
+    PORT(
+         CLK : IN  std_logic;
+         RST : IN  std_logic;
+         IADDR : OUT  std_logic_vector(31 downto 0);
+         IDATA : IN  std_logic_vector(31 downto 0);
+         IEN : OUT  std_logic;
+         DADDR : OUT  std_logic_vector(31 downto 0);
+         DOUT : OUT  std_logic_vector(31 downto 0);
+         DIN : IN  std_logic_vector(31 downto 0);
+         DOP : OUT  std_logic;
+         DEN : OUT  std_logic
+        );
+    END COMPONENT;
+    
+
+   --Inputs
+   signal CLK : std_logic;
+   signal RST : std_logic;
+   signal IDATA : std_logic_vector(31 downto 0);
+   signal DIN : std_logic_vector(31 downto 0);
+
+ 	--Outputs
+   signal IADDR : std_logic_vector(31 downto 0);
+   signal IEN : std_logic;
+   signal DADDR : std_logic_vector(31 downto 0);
+   signal DOUT : std_logic_vector(31 downto 0);
+   signal DOP : std_logic;
+   signal DEN : std_logic;
+ 
+BEGIN
+ 
+	-- Instantiate the Unit Under Test (UUT)
+   uut: MIPS_32 PORT MAP (
+          CLK => CLK,
+          RST => RST,
+          IADDR => IADDR,
+          IDATA => IDATA,
+          IEN => IEN,
+          DADDR => DADDR,
+          DOUT => DOUT,
+          DIN => DIN,
+          DOP => DOP,
+          DEN => DEN
+        );
+
+	process
+	begin
+		CLK <= '1';
+		wait for 25 ns;
+		CLK <= '0';
+		wait for 25 ns;
+	end process;
+	
+   -- Stimulus process
+   stim_proc: process
+   begin		
+		RST   <= '1';
+		IDATA <= (others => '0');
+		DIN   <= (others => '0');
+      wait for 50 ns;
+		
+		RST   <= '0';
+      wait for 50 ns;
+		
+		-- j 1
+		IDATA <= x"08000001";
+		wait for 50 ns;
+		
+		IDATA <= x"00000000";
+		wait for 50 ns;
+		
+		-- j 100
+		IDATA <= x"08000064";
+		wait for 50 ns;
+		
+		IDATA <= x"00000000";
+		wait for 50 ns;
+		
+		-- j 67108863
+		IDATA <= x"0BFFFFFF";
+		wait for 50 ns;
+		
+		IDATA <= x"00000000";
+		wait for 50 ns;
+		
+		-- lui $t0, 1234
+		IDATA <= x"3c0804d2";
+		wait for 50 ns;
+		
+		-- ori $t0, $t0, 456
+		IDATA <= x"350801c8";
+		wait for 50 ns;
+		
+		-- jr $t0
+		IDATA <= x"01000008";
+		wait for 50 ns;
+		
+		IDATA <= x"00000000";
+		wait for 50 ns;
+		
+		-- jr $ra
+		IDATA <= x"03e00008";
+		wait for 50 ns;
+		
+		IDATA <= x"00000000";
+		wait for 50 ns;
+		
+		-- jal 67108863
+		IDATA <= x"0FFFFFFF";
+		wait for 50 ns;
+		
+		-- addi $t0, $ra, 0
+		IDATA <= x"23e80000";
+		wait for 50 ns;
+		
+		-- jr $ra
+		-- IDATA <= x"03e00008";
+		-- wait for 50 ns;
+		
+		-- addi $t2, $t2, 1245
+		IDATA <= x"214a04dd";
+		wait for 50 ns;
+		
+		-- beq $t2, $t2, 1
+		IDATA <= x"114a0001";
+		wait for 50 ns;
+		
+		-- bne $t2, $t2, 1
+		IDATA <= x"154a0001";
+		wait for 50 ns;
+		wait;
+   end process;
+
+END;

--- a/test/TB_MIPS_32_LOGIC.vhd
+++ b/test/TB_MIPS_32_LOGIC.vhd
@@ -1,0 +1,115 @@
+LIBRARY ieee;
+USE ieee.std_logic_1164.ALL;
+ 
+ENTITY TB_MIPS_32_LOGIC IS
+END TB_MIPS_32_LOGIC;
+ 
+ARCHITECTURE behavior OF TB_MIPS_32_LOGIC IS 
+ 
+    -- Component Declaration for the Unit Under Test (UUT)
+ 
+    COMPONENT MIPS_32
+    PORT(
+         CLK : IN  std_logic;
+         RST : IN  std_logic;
+         IADDR : OUT  std_logic_vector(31 downto 0);
+         IDATA : IN  std_logic_vector(31 downto 0);
+         IEN : OUT  std_logic;
+         DADDR : OUT  std_logic_vector(31 downto 0);
+         DOUT : OUT  std_logic_vector(31 downto 0);
+         DIN : IN  std_logic_vector(31 downto 0);
+         DOP : OUT  std_logic;
+         DEN : OUT  std_logic
+        );
+    END COMPONENT;
+    
+
+   --Inputs
+   signal CLK : std_logic;
+   signal RST : std_logic;
+   signal IDATA : std_logic_vector(31 downto 0);
+   signal DIN : std_logic_vector(31 downto 0);
+
+ 	--Outputs
+   signal IADDR : std_logic_vector(31 downto 0);
+   signal IEN : std_logic;
+   signal DADDR : std_logic_vector(31 downto 0);
+   signal DOUT : std_logic_vector(31 downto 0);
+   signal DOP : std_logic;
+   signal DEN : std_logic;
+ 
+BEGIN
+ 
+	-- Instantiate the Unit Under Test (UUT)
+   uut: MIPS_32 PORT MAP (
+          CLK => CLK,
+          RST => RST,
+          IADDR => IADDR,
+          IDATA => IDATA,
+          IEN => IEN,
+          DADDR => DADDR,
+          DOUT => DOUT,
+          DIN => DIN,
+          DOP => DOP,
+          DEN => DEN
+        );
+
+	process
+	begin
+		CLK <= '1';
+		wait for 25 ns;
+		CLK <= '0';
+		wait for 25 ns;
+	end process;
+	
+   -- Stimulus process
+   stim_proc: process
+   begin		
+		RST   <= '1';
+		IDATA <= (others => '0');
+		DIN   <= (others => '0');
+      wait for 50 ns;
+		
+		RST   <= '0';
+      wait for 50 ns;
+		
+		-- addi $t3, $t3, 145
+		IDATA <= x"216b0091";
+		wait for 50 ns;
+		
+		-- addi $t4, $t4, 8
+		IDATA <= x"218c0008";
+		wait for 50 ns;
+		
+		-- xor $t7, $t3, $t4
+		IDATA <= x"016c7826";
+		wait for 50 ns;
+		
+		-- andi $t7, $t3, 100
+		IDATA <= x"316f0064";
+		wait for 50 ns;
+		
+		-- andi $t7, $t3, 128
+		IDATA <= x"316f0080";
+		wait for 50 ns;
+		
+		-- xori $t5, $t7, 128
+		IDATA <= x"39ed0080";
+		wait for 50 ns;
+		
+		-- xori $t5, $t7, 1
+		IDATA <= x"39ed0001";
+		wait for 50 ns;
+		
+		-- xori $t5, $t7, 65535
+		IDATA <= x"39edffff";
+		wait for 50 ns;
+		
+		-- ori $t5, $t7, 65535
+		IDATA <= x"354dffff";
+		wait for 50 ns;
+		
+		wait;
+   end process;
+
+END;

--- a/test/TB_MIPS_32_s.vhd
+++ b/test/TB_MIPS_32_s.vhd
@@ -1,10 +1,10 @@
 LIBRARY ieee;
 USE ieee.std_logic_1164.ALL;
  
-ENTITY TB_MIPS_32 IS
-END TB_MIPS_32;
+ENTITY TB_MIPS_32_S IS
+END TB_MIPS_32_S;
  
-ARCHITECTURE behavior OF TB_MIPS_32 IS 
+ARCHITECTURE behavior OF TB_MIPS_32_S IS 
  
     -- Component Declaration for the Unit Under Test (UUT)
  
@@ -73,45 +73,75 @@ BEGIN
 		RST   <= '0';
       wait for 50 ns;
 		
-		-- addi $t0, $t0, 4
-		IDATA <= x"21080004";
+		-- addi $t3, $t3, 24
+		IDATA <= x"216b0018";
 		wait for 50 ns;
 		
-		-- addi $t1, $t1, 8
-		IDATA <= x"21290008";
+		-- addi $t4, $t4, 8
+		IDATA <= x"218c0008";
 		wait for 50 ns;
 		
-		-- addi $t2, $t1, $t0
-		IDATA <= x"01285020";
+		-- sll $t1, $t3, 4
+		IDATA <= x"000b4900";
 		wait for 50 ns;
 		
-		-- sub $t3, $t1, $t0
-		IDATA <= x"01285822";
+		-- sll $t1, $t3, 1
+		IDATA <= x"000b4840";
 		wait for 50 ns;
 		
-		-- and $t4, $t2, $t1
-		IDATA <= x"01496024";
+		-- sll $t1, $t3, 31
+		IDATA <= x"000b4fc0";
 		wait for 50 ns;
 		
-		-- lui $t5, 123
-		IDATA <= x"3c0d007b";
+		-- srl $t4, $t3, 10
+		IDATA <= x"000b6282";
 		wait for 50 ns;
 		
-		-- addi $t0, $t5, 8
-		IDATA <= x"21a80008";
+		-- srl $t4, $t3, 2
+		IDATA <= x"000b6082";
 		wait for 50 ns;
 		
-		-- addi $t1, $t1, 500
-		IDATA <= x"212901f4";
+		-- srl $t4, $t3, 0
+		IDATA <= x"000b6002";
 		wait for 50 ns;
 		
-		-- sub $t3, $t0, $t1
-		IDATA <= x"01095822";
+		-- sra $t4, $t3, 1
+		IDATA <= x"000b6043";
 		wait for 50 ns;
 		
+		-- lui $t4, 65535
+		IDATA <= x"3c0cffff";
+		wait for 50 ns;
 		
-
-      wait;
+		-- sra $t4, $t4, 16
+		IDATA <= x"000c6403";
+		wait for 50 ns;
+		
+		-- now set if less ...
+		-- slt $t4, $t4, $t3
+		IDATA <= x"018b782a";
+		wait for 50 ns;
+		
+		-- slt $t4, $t3, $t4
+		IDATA <= x"016c782a";
+		wait for 50 ns;
+		
+		-- slt $t5, $t5, $t5
+		IDATA <= x"01ad682a";
+		wait for 50 ns;
+		
+		-- slt $t5, $t6, $t3
+		IDATA <= x"01cb682a";
+		wait for 50 ns;
+		
+		-- add $t4, $t7, $t4
+		IDATA <= x"01ec6020";
+		wait for 50 ns;
+		
+		-- slt $t5, $t4, $t7
+		IDATA <= x"018f682a";
+		
+		wait;
    end process;
 
 END;

--- a/test/TB_MIPS_SL.vhd
+++ b/test/TB_MIPS_SL.vhd
@@ -1,0 +1,132 @@
+LIBRARY ieee;
+USE ieee.std_logic_1164.ALL;
+ 
+ENTITY TB_MIPS_32_SL IS
+END TB_MIPS_32_SL;
+ 
+ARCHITECTURE behavior OF TB_MIPS_32_SL IS 
+ 
+    -- Component Declaration for the Unit Under Test (UUT)
+ 
+    COMPONENT MIPS_32
+    PORT(
+         CLK : IN  std_logic;
+         RST : IN  std_logic;
+         IADDR : OUT  std_logic_vector(31 downto 0);
+         IDATA : IN  std_logic_vector(31 downto 0);
+         IEN : OUT  std_logic;
+         DADDR : OUT  std_logic_vector(31 downto 0);
+         DOUT : OUT  std_logic_vector(31 downto 0);
+         DIN : IN  std_logic_vector(31 downto 0);
+         DOP : OUT  std_logic;
+         DEN : OUT  std_logic
+        );
+    END COMPONENT;
+    
+   --Inputs
+   signal CLK : std_logic;
+   signal RST : std_logic;
+   signal IDATA : std_logic_vector(31 downto 0);
+   signal DIN : std_logic_vector(31 downto 0);
+
+ 	--Outputs
+   signal IADDR : std_logic_vector(31 downto 0);
+   signal IEN : std_logic;
+   signal DADDR : std_logic_vector(31 downto 0);
+   signal DOUT : std_logic_vector(31 downto 0);
+   signal DOP : std_logic;
+   signal DEN : std_logic;
+ 
+BEGIN
+
+	-- Instantiate the Unit Under Test (UUT)
+   uut: MIPS_32 PORT MAP (
+          CLK => CLK,
+          RST => RST,
+          IADDR => IADDR,
+          IDATA => IDATA,
+          IEN => IEN,
+          DADDR => DADDR,
+          DOUT => DOUT,
+          DIN => DIN,
+          DOP => DOP,
+          DEN => DEN
+        );
+
+	process
+	begin
+		CLK <= '1';
+		wait for 25 ns;
+		CLK <= '0';
+		wait for 25 ns;
+	end process;
+	
+   -- Stimulus process
+   stim_proc: process
+   begin		
+		RST   <= '1';
+		IDATA <= (others => '0');
+		DIN   <= (others => '0');
+      wait for 50 ns;
+		
+		RST   <= '0';
+      wait for 50 ns;
+		
+		-- addi $t3, $t3, 100
+		IDATA <= x"216b0064";
+		wait for 50 ns;
+		
+		-- addi $t4, $t4, 20
+		IDATA <= x"218c0014";
+		wait for 50 ns;
+		
+		-- sltu $t6, $t4, $t5
+		IDATA <= x"018d702b";
+		wait for 50 ns;
+		
+		-- sltu $t6, $t5, $t4
+		IDATA <= x"01ac702b";
+		wait for 50 ns;
+		
+		-- sltu $t7, $s0, $s1
+		IDATA <= x"0211782b";
+		wait for 50 ns;
+		
+		-- lui $s0, 65535
+		IDATA <= x"3c10ffff";
+		wait for 50 ns;
+		
+		-- ori $s0, $s0, 23
+		IDATA <= x"36100017";
+		wait for 50 ns;
+		
+		-- sltu $t7, $s0, $t3
+		IDATA <= x"020b782b";
+		wait for 50 ns;
+		
+		-- sltu $t7, $t3, $s0
+		IDATA <= x"0170782b";
+		wait for 50 ns;
+		
+		-- slti $t7, $t3, 50
+		IDATA <= x"296f0032";
+		wait for 50 ns;
+		
+		-- slti $t7, $t3, 220
+		IDATA <= x"296f00dc";
+		wait for 50 ns;
+		
+		-- slti $t7, $t3, 120
+		IDATA <= x"296f0078";
+		wait for 50 ns;
+		
+		-- sltiu $t7, $t3, 32767
+		IDATA <= x"2d6f7fff";
+		wait for 50 ns;
+		
+		-- sltiu $t7, $t3, 50
+		IDATA <= x"2d6f0032";
+		wait;
+   end process;
+
+END;


### PR DESCRIPTION
Test MIPS 32, funzionalità testate:

add, sub, addi, and, or, nor, xor, and, ori, xori, sll, srl, sra, slt, sltu, sltiu, j, jal, jr, beq, bne.

Da verificare la faccenda del signext e jal da testare a parte con un programma

Ho creato i seguenti file per i test:
TB_MIPS_32_BRANCH -> testa I branch
TB_MIPS_32_LOGIC -> testa le logiche
TB_MIPS_32_s -> testa gli shift
TB_MIPS_32_SL -> testa gli srl / sll 

Ho anche aggiunto i fixed bug per la Control Unit e MIPS_32
