### PR TITLE
Fix memoria

### DIFF
--- a/moduli/MEMORY.vhd
+++ b/moduli/MEMORY.vhd
@@ -43,6 +43,9 @@ begin
 			-- MEMORY INITIALIZATION
 			if(RST = '1') then
 			
+				IDATA <= (others => '0');
+				DOUT <= (others => '0');
+				
 				file_open(READ_FILE, "initial_mem_state.txt", read_mode);
 				
 				while not endfile(READ_FILE) loop
@@ -66,6 +69,16 @@ begin
 				
 			-- ACCESS TO MEMORY
 			else
+				if(IEN = '1') then
+					I_INDEX := to_integer(unsigned(IADDR));
+						
+					if(I_INDEX + 4 < 1024) then
+						IDATA <= RAM(I_INDEX)     & 
+									RAM(I_INDEX + 1) & 
+									RAM(I_INDEX + 2) & 
+									RAM(I_INDEX + 3);
+					end if;
+				end if;
 				-- WRITE
 				if(DOP = '1') then 
 					if(DEN = '1') then
@@ -91,16 +104,6 @@ begin
 									  RAM(D_INDEX + 3);
 						end if;
 						
-					end if;
-					if(IEN = '1') then
-						I_INDEX := to_integer(unsigned(IADDR));
-						
-						if(I_INDEX + 4 < 1024) then
-							IDATA <= RAM(I_INDEX)     & 
-										RAM(I_INDEX + 1) & 
-										RAM(I_INDEX + 2) & 
-										RAM(I_INDEX + 3);
-						end if;
 					end if;
 				end if;
 			end if;


### PR DESCRIPTION
Adesso non serve che DOP sia su read (0) per leggere un'istruzione, basta che IEN sia a 1 e al fronte di clock successivo IDATA conterrà l'istruzione contenuta nella cella d'indirizzo IADDR.