### PR TITLE
Registri nel top level

### DIFF
--- a/moduli/REGFILE.vhd
+++ b/moduli/REGFILE.vhd
@@ -1,7 +1,14 @@
 
+use work.MUX_PKG.ALL;
+
+package REGFILE_PKG is
+  signal REGS_DATA : SLV_ARRAY(0 to 31);
+end package REGFILE_PKG  ; 
+
 library IEEE;
 use IEEE.STD_LOGIC_1164.ALL;
 use work.MUX_PKG.ALL;
+use work.REGFILE_PKG.ALL;
 
 entity REGFILE is
     port(
@@ -139,6 +146,6 @@ begin
 		MUX_OUT => D1
 	);
 	
-	
+	REGS_DATA <= REG_OUT;
 	
 end RTL;

--- a/test/TB_TL_AND_MEM.vhd
+++ b/test/TB_TL_AND_MEM.vhd
@@ -1,6 +1,8 @@
 LIBRARY ieee;
 USE ieee.std_logic_1164.ALL;
- 
+use work.REGFILE_PKG.ALL;
+use work.MUX_PKG.ALL;
+
 -- Uncomment the following library declaration if using
 -- arithmetic functions with Signed or Unsigned values
 --USE ieee.numeric_std.ALL;
@@ -59,9 +61,10 @@ ARCHITECTURE behavior OF TB_TL_AND_MEM IS
    signal DOUT : std_logic_vector(31 downto 0);
    signal DOP : std_logic;
    signal DEN : std_logic;
-
+	signal REGISTERS : SLV_ARRAY(0 to 31) := (others=>(others=>'0'));
+   signal REGS_READY : std_logic := '0';
    -- Clock period definitions
-   constant CLK_period : time := 50 ns;
+   constant CLK_period : time := 100 ns;
  
 BEGIN
  
@@ -102,8 +105,8 @@ BEGIN
    end process;
  
 
-   -- Stimulus process
-   stim_proc: process
+   -- Reset process
+   RST_proc: process
    begin		
 		RST <= '1';
 		wait for 100 ns; 
@@ -111,5 +114,16 @@ BEGIN
 		RST <= '0'; 
       wait;
    end process;
-
+	
+	-- End programm process
+   END_proc: process(CLK)
+   begin		
+		if(IDATA = x"00000000") then
+			REGS_READY <= '1';
+			REGISTERS <= REGS_DATA;
+		else
+			REGS_READY <= '0';
+			REGISTERS <= (others=>(others=>'0'));
+		end if;
+   end process;
 END;


### PR DESCRIPTION
Aggiunto un segnale globale che permette di passare il valore dei registri fino al top level per mostrarli anche in simulazioni post place and route (se va). Il segnale in uscita dal top level è assegnato solo quando il programma "termina", cioé viene letta un'istruzione NOP. Un segnale logico permette di vedere più facilmente quando un'istruzione NOP è letta.